### PR TITLE
Fix GeoPoint creation with two arguments

### DIFF
--- a/lib/geopoint.js
+++ b/lib/geopoint.js
@@ -53,15 +53,16 @@ module.exports = GeoPoint;
  */
 
 function GeoPoint(data) {
-  if (!(this instanceof GeoPoint)) {
-    return new GeoPoint(data);
-  }
-
+  // if called with two arguments
   if (arguments.length === 2) {
     data = {
       lat: arguments[0],
       lng: arguments[1],
     };
+  }
+
+  if (!(this instanceof GeoPoint)) {
+    return new GeoPoint(data);
   }
 
   assert(

--- a/test/geopoint.test.js
+++ b/test/geopoint.test.js
@@ -39,6 +39,14 @@ describe('GeoPoint', function() {
       point.lng.should.equal(150);
     });
 
+    it('supports coordinates as inline parameters without new keyword',
+      function() {
+        var point = GeoPoint(-34, 150);
+
+        point.lat.should.equal(-34);
+        point.lng.should.equal(150);
+      });
+
     it('rejects invalid parameters', function() {
       var fn = function() {
         new GeoPoint('150,-34');


### PR DESCRIPTION
Creating GeoPoint like `var a = GeoPoint(2,3)` -
without `new` keyword - fails as the second argument
is not handled.
This fix addresses above issue by rearranging existing
code block and makes behavior of creating GeoPoint with
two arguments consistent, with or wihtout `new`