### PR TITLE
Fix coercion of null & boolean

### DIFF
--- a/lib/geopoint.js
+++ b/lib/geopoint.js
@@ -75,6 +75,15 @@ function GeoPoint(data) {
     assert(data.length === 2,
       'must provide a string "lat,lng" creating a GeoPoint with a string');
   }
+
+  // check for any null values as Number() converts it to 0
+  assert(checkForNullValues(data),
+    'lat & lng must be a number when creating GeoPoint');
+
+  // check for any boolean values as Number() converts it to 0 or 1
+  assert(checkForBooleanValues(data),
+     'lat & lng must be a number when creating GeoPoint');
+
   if (Array.isArray(data)) {
     assert(data.length === 2,
       'must provide valid geo-cordinates array [lat, lng]');
@@ -84,10 +93,21 @@ function GeoPoint(data) {
       lng: Number(data[1]),
     };
   } else {
+    assert(data.hasOwnProperty('lat') &&
+      data.hasOwnProperty('lng'),
+      'must provide a lat and lng object when creating a GeoPoint');
+
     data.lng = Number(data.lng);
     data.lat = Number(data.lat);
   }
 
+  validateValues(data);
+
+  this.lat = data.lat;
+  this.lng = data.lng;
+}
+
+function validateValues(data) {
   assert(typeof data === 'object',
     'must provide a lat and lng object when creating a GeoPoint');
   assert(typeof data.lat === 'number' && !isNaN(data.lat),
@@ -98,11 +118,23 @@ function GeoPoint(data) {
   assert(data.lng >= -180, 'lng must be >= -180');
   assert(data.lat <= 90, 'lat must be <= 90');
   assert(data.lat >= -90, 'lat must be >= -90');
-
-  this.lat = data.lat;
-  this.lng = data.lng;
 }
 
+function checkForBooleanValues(data) {
+  if (Array.isArray(data)) {
+    return !(typeof data[0] === 'boolean' || typeof data[1] === 'boolean');
+  } else {
+    return !(typeof data.lat === 'boolean' || typeof data.lng === 'boolean');
+  }
+}
+
+function checkForNullValues(data) {
+  if (Array.isArray(data)) {
+    return !(data[0] === null || data[1] === null);
+  } else {
+    return !(data.lat === null || data.lng === null);
+  }
+}
 /**
  * Determine the spherical distance between two GeoPoints.
  *

--- a/test/geopoint.test.js
+++ b/test/geopoint.test.js
@@ -48,42 +48,75 @@ describe('GeoPoint', function() {
       });
 
     it('rejects invalid parameters', function() {
+      // invalid string value throws error
+      fn = function() {
+        new GeoPoint('invalid_string');
+      };
+      fn.should.throw();
+
+      // lattitude cannot be out of +/-90 degree range
       var fn = function() {
         new GeoPoint('150,-34');
       };
       fn.should.throw();
 
       fn = function() {
-        new GeoPoint('invalid_string');
+        new GeoPoint([-94, -34]);
       };
       fn.should.throw();
 
-      fn = function() {
-        new GeoPoint([150, -34]);
-      };
-      fn.should.throw();
-
+      // longitude cannot be out of +/-180 degree range
       fn = function() {
         new GeoPoint({
-          lat: 150,
-          lng: null,
+          lat: 10,
+          lng: 181,
         });
       };
       fn.should.throw();
 
       fn = function() {
-        new GeoPoint(150, -34);
+        new GeoPoint(10, -181);
       };
       fn.should.throw();
 
+      // empty values throw error
       fn = function() {
         new GeoPoint();
       };
       fn.should.throw();
 
-      // array with more than two elements is not allowed
+      fn = function() {
+        new GeoPoint({});
+      };
+      fn.should.throw();
+
+      fn = function() {
+        new GeoPoint([]);
+      };
+      fn.should.throw();
+
+      // array with more than two elements throws error
       fn = function() {
         new GeoPoint([70, -34, 33, 4]);
+      };
+      fn.should.throw();
+
+      // boolean is not allowed
+      fn = function() {
+        new GeoPoint(3, true);
+      };
+      fn.should.throw();
+
+      // null is not allowed
+      fn = function() {
+        new GeoPoint(null, -34);
+      };
+      fn.should.throw();
+
+      // undefined is not allowed
+      fn = function() {
+        var undef;
+        new GeoPoint(undef, -34);
       };
       fn.should.throw();
     });


### PR DESCRIPTION
**First commit**
Creating GeoPoint with `null` or `boolean`:`true`, `false` coerces
 - `null` to `0`
 - `true` to `1`
 - `false` to `0`
which is wrong. This commit fixes it by enforcing
checks for boolean & null values

**Second commit**
Fix assertion for invalid Obj & reformat tests
- Adds a check for invalid Object inputs
- Adds information about tests where required
- Extracts validations to a helper function