### PR TITLE
Update check for input array length

### DIFF
--- a/lib/geopoint.js
+++ b/lib/geopoint.js
@@ -76,6 +76,9 @@ function GeoPoint(data) {
       'must provide a string "lat,lng" creating a GeoPoint with a string');
   }
   if (Array.isArray(data)) {
+    assert(data.length === 2,
+      'must provide valid geo-cordinates array [lat, lng]');
+
     data = {
       lat: Number(data[0]),
       lng: Number(data[1]),

--- a/test/geopoint.test.js
+++ b/test/geopoint.test.js
@@ -80,6 +80,12 @@ describe('GeoPoint', function() {
         new GeoPoint();
       };
       fn.should.throw();
+
+      // array with more than two elements is not allowed
+      fn = function() {
+        new GeoPoint([70, -34, 33, 4]);
+      };
+      fn.should.throw();
     });
   });
 


### PR DESCRIPTION
Currently, creating GeoPoint as:
`new GeoPoint([2,4,6,7])`, quietly ignores
array elements other than the first two i.e. 2,4.
This commit adds a check for array length and
throws if input array.length greater/less than 2.